### PR TITLE
Fixed error when calling `isButtonExempt` with a non-empty exception list

### DIFF
--- a/lua/weapons/weapon_hdevice/shared.lua
+++ b/lua/weapons/weapon_hdevice/shared.lua
@@ -120,7 +120,7 @@ end
 local function isButtonExempt(id)
 	if not hdevicereloaded.exceptionButtonID then return false end
 	if not hdevicereloaded.exceptionButtonID[game.GetMap()] then return false end
-	return hdevicereloaded.exceptionButtonID[game.GetMap()][ent:MapCreationID()] 
+	return hdevicereloaded.exceptionButtonID[game.GetMap()][id]
 end
 
 function SWEP:PrimaryAttack()


### PR DESCRIPTION
Fixed an error caused by the new function `isButtonExempt` (from #7) happening only when the exception list was created for the current map.